### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/unix-tools/geoip.md
+++ b/unix-tools/geoip.md
@@ -8,7 +8,7 @@ GeoIP City Edition, Rev 1: US, TX, Texas, Austin, 78744, 30.176001, -97.737297, 
 
 
 La base de datos de ASNs tenemos que bajarla a mano:
-http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
 
 
 Actualizar las bbdd de pais y ciudad cada dia:


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).